### PR TITLE
Automate releases with GoReleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Release
+"on":
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch: {}
+permissions:
+  contents: write
+jobs:
+  goreleaser:
+    name: GoReleaser
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          check-latest: true
+          go-version: 1.26.2
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,34 +6,29 @@
 version: 2
 
 archives:
-  - name_template: '{{ .ProjectName }}-{{ replace .Version "v" "" }}-{{ .Os }}-{{ .Arch }}'
-    format_overrides:
-      - goos: windows
-        format: zip
-    files:
-      - CHANGELOG.md
-      - LICENSE
-      - README.md
+  - formats:
+      - binary
+    name_template: '{{ if eq .Os "darwin" }}hermescli_darwin{{ else }}hermescli{{ end }}'
 
 checksum:
-  name_template: "checksums.txt"
+  disable: true
 
 builds:
-  - binary: 'hermescli'
+  - id: hermescli
+    # Keep internal build artifact names distinct from the uploaded legacy names
+    # below, otherwise GoReleaser records duplicate artifact names.
+    binary: 'hermescli_{{ .Target }}'
     env:
       - CGO_ENABLED=0
-    goos:
-      - linux
-      - windows
-      - darwin
-    goarch:
-      - amd64
-      - arm64
-    ignore:
-      - goos: windows
-        goarch: arm64
+    targets:
+      - linux_amd64_v1
+      - windows_amd64_v1
+      - darwin_amd64_v1
+    flags:
+      - -mod=vendor
     ldflags:
       - -s -w
+      - -X github.com/sapcc/hermescli/client.Version={{ .Version }}
       - -X github.com/sapcc/go-api-declarations/bininfo.binName=hermescli
       - -X github.com/sapcc/go-api-declarations/bininfo.version={{ .Version }}
       - -X github.com/sapcc/go-api-declarations/bininfo.commit={{ .FullCommit  }}


### PR DESCRIPTION
## Summary

- add a tag-triggered GoReleaser workflow for `vX.Y.Z` releases
- configure GoReleaser to publish the existing raw binary asset names: `hermescli`, `hermescli.exe`, and `hermescli_darwin`
- embed `client.Version` through ldflags so `hermescli version` reports the release tag

## Validation

- `go run github.com/goreleaser/goreleaser/v2@latest check`
- `go run github.com/goreleaser/goreleaser/v2@latest release --snapshot --clean --skip=publish`
- snapshot artifact names: `hermescli`, `hermescli.exe`, `hermescli_darwin`
- snapshot Darwin binary: `hermescli v0.5.9-next compiled with go1.26.2 on darwin/amd64`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yaml`
- `make build/cover.out`
- `git diff --check`

Note: `reuse lint` only fails because of unrelated untracked `.claude/` files in the local worktree.
