### PR TITLE
Support `hermescli version` with go-api-declarations bininfo package

### DIFF
--- a/client/version.go
+++ b/client/version.go
@@ -7,10 +7,9 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/sapcc/go-api-declarations/bininfo"
 	"github.com/spf13/cobra"
 )
-
-var Version = "dev"
 
 var VersionCmd = &cobra.Command{
 	Use:               "version",
@@ -18,7 +17,7 @@ var VersionCmd = &cobra.Command{
 	DisableAutoGenTag: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Printf("hermescli %s compiled with %v on %v/%v\n",
-			Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+			bininfo.Version(), runtime.Version(), runtime.GOOS, runtime.GOARCH)
 	},
 }
 

--- a/vendor/github.com/sapcc/go-api-declarations/bininfo/argument.go
+++ b/vendor/github.com/sapcc/go-api-declarations/bininfo/argument.go
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package bininfo
+
+import (
+	"fmt"
+	"os"
+)
+
+// HandleVersionArgument prints the version string and exits if the first argument to the program is --version
+// This function is recommended for simple go programs without an argument parsing library and should be called very early in the main function.
+func HandleVersionArgument() {
+	args := os.Args[1:]
+	if len(args) > 0 {
+		if args[0] == "--version" {
+			fmt.Printf("%s version %s\n", binName, version)
+			os.Exit(0)
+		}
+	}
+}

--- a/vendor/github.com/sapcc/go-api-declarations/bininfo/bininfo.go
+++ b/vendor/github.com/sapcc/go-api-declarations/bininfo/bininfo.go
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+// Package bininfo contains information about the current binary and process.
+// Most of the information available through this interface is filled at build
+// time using the -X linker flag.
+//
+// This package can be considered an interface between the application (which
+// provides the requisite data at build time and runtime) and various places
+// around our internal libraries (which use this data, e.g. to construct
+// User-Agent headers or log messages).
+//
+// When using <https://github.com/sapcc/go-makefile-maker>, go-makefile-maker
+// will detect when go-api-declarations is listed as a dependency in the
+// application's go.mod file and generate the appropriate linker flags
+// automatically.
+package bininfo
+
+import "fmt"
+
+var (
+	// These variables are filled at buildtime with the -X linker flag. Everything
+	// except for `binName` may be empty if the build could not determine a value.
+	binName   string
+	version   string
+	commit    string
+	buildDate string
+	// This always starts blank and is filled by SetTaskName().
+	taskName string
+)
+
+// Component returns the name of the current binary, followed by the name of the
+// current process's task if one has provided via SetTaskName(). This string can
+// be used to identify the current process, e.g. in User-Agent headers.
+//
+// For example, the command `tenso worker` calls `SetTaskName("worker")`, so
+// Component() will return "tenso-worker".
+func Component() string {
+	if taskName == "" {
+		return binName
+	}
+	return fmt.Sprintf("%s-%s", binName, taskName)
+}
+
+// SetTaskName identifies the subcommand selected for the current process. This
+// setting influences the output of Component().
+func SetTaskName(name string) {
+	taskName = name
+}
+
+// Version returns the version string provided at build time, or "" if none was
+// provided.
+//
+// This can for example be used like the following with the cobra argument parsing library:
+//
+// ```go
+//
+//	cobra.Command{
+//	  ...
+//	  Version: bininfo.Version(),
+//	  ...
+//	}
+//
+// ```
+func Version() string {
+	return version
+}
+
+// VersionOr returns the version string provided at build time, or the fallback
+// value if none was provided. A common invocation is `VersionOr("unknown")`.
+func VersionOr(fallback string) string {
+	if version == "" {
+		return fallback
+	}
+	return version
+}
+
+// Commit returns the commit string provided at build time, or "" if none was
+// provided.
+func Commit() string {
+	return commit
+}
+
+// CommitOr returns the commit string provided at build time, or the fallback
+// value if none was provided. A common invocation is `CommitOr("unknown")`.
+func CommitOr(fallback string) string {
+	if commit == "" {
+		return fallback
+	}
+	return commit
+}
+
+// BuildDate returns the buildDate string provided at build time, or "" if none was
+// provided.
+func BuildDate() string {
+	return buildDate
+}
+
+// BuildDateOr returns the build date string, or the fallback value if none is
+// known. A common invocation is `BuildDateOr("unknown")`.
+func BuildDateOr(fallback string) string {
+	if buildDate == "" {
+		return fallback
+	}
+	return buildDate
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -94,6 +94,7 @@ github.com/pelletier/go-toml/v2/unstable
 github.com/sagikazarmark/locafero
 # github.com/sapcc/go-api-declarations v1.22.0
 ## explicit; go 1.24
+github.com/sapcc/go-api-declarations/bininfo
 github.com/sapcc/go-api-declarations/cadf
 # github.com/sapcc/go-bits v0.0.0-20260519090007-308851876285
 ## explicit; go 1.26


### PR DESCRIPTION
go-makefile-maker automatically injects version information for the
github.com/sapcc/go-api-declarations/bininfo package - this exposes the
version via the version command.

e.g.:

`hermescli v0.5.9-9-gb1756bf compiled with go1.26.3 on darwin/arm64`
