### PR TITLE
fix(table): use per-cell content cap for tablewriter v1

### DIFF
--- a/client/list.go
+++ b/client/list.go
@@ -337,7 +337,11 @@ var ListCmd = &cobra.Command{
 
 		if format == "table" {
 			var buf bytes.Buffer
-			table := tablewriter.NewTable(&buf, tablewriter.WithColumnMax(20), tablewriter.WithRowAlignment(tw.AlignRight))
+			table := tablewriter.NewTable(&buf,
+				tablewriter.WithHeaderMaxWidth(20),
+				tablewriter.WithRowMaxWidth(20),
+				tablewriter.WithRowAlignment(tw.AlignRight),
+			)
 			table.Header(keyOrder)
 
 			for _, v := range allEvents {

--- a/client/show.go
+++ b/client/show.go
@@ -101,7 +101,11 @@ var ShowCmd = &cobra.Command{
 
 				// create table
 				var buf bytes.Buffer
-				table := tablewriter.NewTable(&buf, tablewriter.WithColumnMax(20), tablewriter.WithRowAlignment(tw.AlignRight))
+				table := tablewriter.NewTable(&buf,
+					tablewriter.WithHeaderMaxWidth(20),
+					tablewriter.WithRowMaxWidth(20),
+					tablewriter.WithRowAlignment(tw.AlignRight),
+				)
 				table.Header("Key", "Value")
 
 				// populate output table


### PR DESCRIPTION
## Summary

`tablewriter` v1's `WithColumnMax(N)` is a fixed per-column width, not the v0 per-cell content cap. With 8 columns, this collapsed every cell to 1–3 chars in `hermescli list`.

Replace with `WithHeaderMaxWidth(20)` + `WithRowMaxWidth(20)` in `client/list.go` and `client/show.go`.

## Test plan

- [x] `gmake build-all`, `go vet`, `go test`, `golangci-lint run` — clean
- [x] Live verified on `qa-de-1`: `list -l 1`, `list -l 3`, `--format json`, `--format yaml` — all exit 0, columns rendered correctly