### PR TITLE
Add list download command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ understands the conventional environment variables for choosing install location
 Hermes CLI offers the following commands:
 
 - `list`: Retrieve a list of audit events
+  - `list download`: Download all matching events to a local file
 - `show`: Show details for a specific event
 - `attributes`: List attributes related to audit events
 - `export`: Export events to Swift
@@ -77,6 +78,74 @@ $ hermescli list --time 2019-04-23T22:07:16+0000 --sort time:asc
 |                                      |                          |                 |        |         | 88c4c917-f5de-43e5-a403-b7c023bfc13d |           |
 +--------------------------------------+--------------------------+-----------------+--------+---------+--------------------------------------+-----------+
 ```
+
+## List Download
+
+Downloads all matching audit events to a local file, bypassing the display limit. Supports the same filter flags as `list`.
+
+### Usage
+
+```sh
+Download all matching Hermes events to a local file
+
+Usage:
+  hermescli list download [flags]
+
+Flags:
+      --action string           filter events by an action
+  -A, --all-projects            include all projects and domains (admin only) (alias for --project-id '*')
+  -h, --help                    help for download
+      --initiator-id string     filter events by an initiator ID
+      --initiator-name string   filter events by an initiator name
+      --outcome string          filter events by an outcome
+  -o, --output string           output file path (use - for stdout) (default "events.json")
+      --project-id string       filter events by the project or domain ID (admin only)
+      --request-path string     filter events by a request path
+      --search string           filter events by a search string
+  -s, --sort strings            sort keys: time, observer_type, target_type, target_id, initiator_type,
+                                initiator_id, outcome, action (suffix :asc or :desc)
+      --source string           filter events by a source
+      --target-id string        filter events by a target ID
+      --target-type string      filter events by a target type
+      --time string             filter events by time
+      --time-end string         filter events till time
+      --time-start string       filter events from time
+
+Global Flags:
+  -c, --column strings   columns to include in CSV output (default: ID, Time, Source, Action, Outcome, RequestPath, Target, Initiator)
+  -d, --debug            print out request and response objects
+  -f, --format string    output format: json, yaml, csv (default "json")
+```
+
+### Output formats
+
+| Format | Flag | Description |
+|--------|------|-------------|
+| JSON   | `--format json` | JSON array of events (default) |
+| YAML   | `--format yaml` | YAML list of events |
+| CSV    | `--format csv`  | CSV with header row; columns controlled by `-c` |
+
+### Examples
+
+```sh
+# Download all events from a time range to JSON (default)
+$ hermescli list download --time-start 2025-08-01T00:00:00Z --time-end 2025-08-31T23:59:59Z -o august.json
+Downloaded 1234 events to august.json
+
+# Download as CSV
+$ hermescli list download --time-start 2025-08-01T00:00:00Z -o events.csv --format csv
+
+# Download with filters
+$ hermescli list download --action create --outcome failure -o failures.json
+
+# Stream to stdout (e.g. pipe to jq)
+$ hermescli list download -o - | jq '[.[] | .action]'
+
+# Admin: download across all projects
+$ hermescli list download -A --time-start 2025-08-01T00:00:00Z -o all-projects.json
+```
+
+> **Note:** Progress is shown on stderr so it does not corrupt file output when using `-o -`.
 
 ## Show
 

--- a/client/list_download.go
+++ b/client/list_download.go
@@ -35,7 +35,8 @@ var listDownloadCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		outputFile := viper.GetString("output")
 
-		// "table" and "value" don't make sense for file output; default to json.
+		// --format defaults to "table" (set by the root persistent flag), which has no meaning for
+		// file output. Coerce it to "json". "value" is also display-only and is rejected explicitly.
 		format := viper.GetString("format")
 		switch format {
 		case "table", "":

--- a/client/list_download.go
+++ b/client/list_download.go
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/cheggaaa/pb/v3"
+	"github.com/sapcc/gophercloud-sapcc/v2/audit/v1/events"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
+)
+
+var listDownloadCmd = &cobra.Command{
+	Use:   "download",
+	Short: "Download all matching Hermes events to a local file",
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if err := viper.BindPFlags(cmd.Flags()); err != nil {
+			return err
+		}
+		teq := viper.GetString("time")
+		tgt := viper.GetString("time-start")
+		tlt := viper.GetString("time-end")
+		if teq != "" && (tgt != "" || tlt != "") {
+			return errors.New("cannot combine time flag with time-start or time-end flags")
+		}
+		return nil
+	},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		outputFile := viper.GetString("output")
+
+		// "table" and "value" don't make sense for file output; default to json.
+		format := viper.GetString("format")
+		switch format {
+		case "table", "":
+			format = "json"
+		case "value":
+			return errors.New(`"value" format is not supported for download, use json, yaml, or csv`)
+		}
+
+		projectID := viper.GetString("project-id")
+		if viper.GetBool("all-projects") {
+			projectID = "*"
+		}
+
+		listOpts := events.ListOpts{
+			Limit:         maxOffset,
+			TargetType:    viper.GetString("target-type"),
+			TargetID:      viper.GetString("target-id"),
+			InitiatorID:   viper.GetString("initiator-id"),
+			InitiatorName: viper.GetString("initiator-name"),
+			Action:        viper.GetString("action"),
+			Outcome:       viper.GetString("outcome"),
+			RequestPath:   viper.GetString("request-path"),
+			ObserverType:  viper.GetString("source"),
+			Search:        viper.GetString("search"),
+			ProjectID:     projectID,
+			Sort:          strings.Join(viper.GetStringSlice("sort"), ","),
+		}
+
+		if t := viper.GetString("time"); t != "" {
+			rt, err := parseTime(t)
+			if err != nil {
+				return fmt.Errorf("failed to parse time: %w", err)
+			}
+			listOpts.Time = []events.DateQuery{{Date: rt}}
+		}
+		if t := viper.GetString("time-start"); t != "" {
+			rt, err := parseTime(t)
+			if err != nil {
+				return fmt.Errorf("failed to parse time-start: %w", err)
+			}
+			listOpts.Time = append(listOpts.Time, events.DateQuery{
+				Date:   rt,
+				Filter: events.DateFilterGTE,
+			})
+		}
+		if t := viper.GetString("time-end"); t != "" {
+			rt, err := parseTime(t)
+			if err != nil {
+				return fmt.Errorf("failed to parse time-end: %w", err)
+			}
+			listOpts.Time = append(listOpts.Time, events.DateQuery{
+				Date:   rt,
+				Filter: events.DateFilterLTE,
+			})
+		}
+
+		hermesClient, err := NewHermesV1Client(cmd.Context())
+		if err != nil {
+			return fmt.Errorf("failed to create Hermes client: %w", err)
+		}
+
+		var allEvents []events.Event
+		var bar *pb.ProgressBar
+		if err = getEvents(cmd.Context(), hermesClient, &allEvents, listOpts, 0, true, &bar); err != nil {
+			if bar != nil {
+				bar.Finish()
+			}
+			return fmt.Errorf("failed to list events: %w", err)
+		}
+		if bar != nil {
+			bar.Finish()
+		}
+
+		var out *os.File
+		if outputFile == "-" {
+			out = os.Stdout
+		} else {
+			out, err = os.Create(outputFile)
+			if err != nil {
+				return fmt.Errorf("failed to create output file: %w", err)
+			}
+			defer out.Close()
+		}
+
+		switch format {
+		case "json":
+			enc := json.NewEncoder(out)
+			enc.SetIndent("", "  ")
+			if err := enc.Encode(allEvents); err != nil {
+				return fmt.Errorf("failed to write JSON: %w", err)
+			}
+		case "yaml":
+			enc := yaml.NewEncoder(out)
+			if err := enc.Encode(allEvents); err != nil {
+				return fmt.Errorf("failed to write YAML: %w", err)
+			}
+			enc.Close()
+		case "csv":
+			keyOrder := viper.GetStringSlice("column")
+			if len(keyOrder) == 0 {
+				keyOrder = defaultListKeyOrder
+			}
+			if err := writeCSV(out, allEvents, keyOrder); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unsupported format %q, use: json, yaml, csv", format)
+		}
+
+		if outputFile != "-" {
+			fmt.Fprintf(os.Stderr, "Downloaded %d events to %s\n", len(allEvents), outputFile)
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	ListCmd.AddCommand(listDownloadCmd)
+	listDownloadCmd.Flags().StringP("output", "o", "events.json", "output file path (use - for stdout)")
+	listDownloadCmd.Flags().StringP("target-type", "", "", "filter events by a target type")
+	listDownloadCmd.Flags().StringP("target-id", "", "", "filter events by a target ID")
+	listDownloadCmd.Flags().StringP("initiator-id", "", "", "filter events by an initiator ID")
+	listDownloadCmd.Flags().StringP("initiator-name", "", "", "filter events by an initiator name")
+	listDownloadCmd.Flags().StringP("action", "", "", "filter events by an action")
+	listDownloadCmd.Flags().StringP("outcome", "", "", "filter events by an outcome")
+	listDownloadCmd.Flags().StringP("request-path", "", "", "filter events by a request path")
+	listDownloadCmd.Flags().StringP("source", "", "", "filter events by a source")
+	listDownloadCmd.Flags().StringP("search", "", "", "filter events by a search string")
+	listDownloadCmd.Flags().StringP("time", "", "", "filter events by time")
+	listDownloadCmd.Flags().StringP("time-start", "", "", "filter events from time")
+	listDownloadCmd.Flags().StringP("time-end", "", "", "filter events till time")
+	listDownloadCmd.Flags().StringP("project-id", "", "", "filter events by the project or domain ID (admin only)")
+	listDownloadCmd.Flags().BoolP("all-projects", "A", false, "include all projects and domains (admin only) (alias for --project-id '*')")
+	listDownloadCmd.Flags().StringSliceP("sort", "s", []string{}, `sort keys: time, observer_type, target_type, target_id, initiator_type, initiator_id, outcome, action (suffix :asc or :desc)`)
+}


### PR DESCRIPTION
## Motivation
The existing `list` command paginates output to the terminal and is not designed for bulk retrieval. Users performing incident response, local analysis, or working in environments without Swift storage had no way to download the full set of matching audit events to a local file.

## What Changed
- Added `hermescli list download` subcommand (`client/list_download.go`) that collects all matching events using the existing pagination logic and writes them to a local file.
- Updated README with full usage, flag reference, output format table, and examples.

## Usage
```sh
hermescli list download --time-start 2025-08-01T00:00:00Z -o events.json
hermescli list download --action create --outcome failure --format csv -o failures.csv
hermescli list download -o - | jq length   # stream to stdout
